### PR TITLE
Adding publish config to try to get it to publish

### DIFF
--- a/packages/obsidian-plugin-tools/package.json
+++ b/packages/obsidian-plugin-tools/package.json
@@ -3,5 +3,9 @@
   "version": "0.0.3",
   "main": "./index.js",
   "repository": "https://github.com/zephraph/obsidian-tools",
-  "author": "zephraph <zephraph@gmail.com>"
+  "author": "zephraph <zephraph@gmail.com>",
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/",
+    "access": "public"
+  }
 }


### PR DESCRIPTION
Just doing this in a separate PR so I can get this thing to publish w/ the updated readme. 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install obsidian-plugin-utils@0.0.4-canary.5.163b4a7.0
  # or 
  yarn add obsidian-plugin-utils@0.0.4-canary.5.163b4a7.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
