### PR TITLE
Fix manfest path and make zip a first class feature

### DIFF
--- a/packages/auto-plugin-obsidian/README.md
+++ b/packages/auto-plugin-obsidian/README.md
@@ -22,16 +22,6 @@ yarn add -D auto-plugin-obsidian
 Add the following to your `.autorc`.
 Without the `dir` option the plugin assumes all distribution files are in the current working directory.
 
-This plugin expects the following project structure.
-
-```txt
-📜 main.js
-📜 styles.css
-📜.autorc
-📜manifest.json
-📜versions.json
-```
-
 ```json
 {
   "plugins": [
@@ -42,17 +32,7 @@ This plugin expects the following project structure.
 }
 ```
 
-### Automated `versions.json`
-
-`auto` handles updating the version in the `manifest.json`, so you should never have to touch that property.
-When depending on a new version of obsidian you need to change the `minAppVersion` to match that version.
-During the next release `auto` will update your compatibility map with the new information.
-
-### Manual Installation
-
-Your plugin might not be on the registry yet but you might still want to work on it and makes releases.
-If the directory where `auto` looks for your distribution files has a `.zip` file in it, that file will also get uploaded to the release.
-This way you can direct users in your `README.md` to manually install the plugin with the zip file.
+This plugin expects the following project structure.
 
 ```txt
 📜 main.js
@@ -60,5 +40,38 @@ This way you can direct users in your `README.md` to manually install the plugin
 📜.autorc
 📜manifest.json
 📜versions.json
-📜my-plugin.zip
 ```
+
+And with a `dir` folder:
+
+```txt
+📂dist
+┣ 📜 main.js
+┣ 📜 styles.css
+📜.autorc
+📜manifest.json
+📜versions.json
+```
+
+### Automated `versions.json`
+
+`auto` handles updating the version in the `manifest.json`, so you should never have to touch that property.
+When depending on a new version of obsidian you need to change the `minAppVersion` to match that version.
+During the next release `auto` will update your compatibility map with the new information.
+
+## Options
+
+### zip
+
+Your plugin might not be on the registry yet but you might still want to work on it and makes releases.
+This way you can direct users in your `README.md` to manually install the plugin with the zip file.
+
+This option will zip your distribution files into a `plugin-manifest-id.json` and add the file to your release.
+
+```json
+{
+  "plugins": [["obsidian", { "zip": true }]]
+}
+```
+
+> NOTE: If you're not using a `dist/` folder you should `.gitignore` the `.zip` file.

--- a/packages/auto-plugin-obsidian/README.md
+++ b/packages/auto-plugin-obsidian/README.md
@@ -22,6 +22,16 @@ yarn add -D auto-plugin-obsidian
 Add the following to your `.autorc`.
 Without the `dir` option the plugin assumes all distribution files are in the current working directory.
 
+This plugin expects the following project structure.
+
+```txt
+📜 main.js
+📜 styles.css
+📜.autorc
+📜manifest.json
+📜versions.json
+```
+
 ```json
 {
   "plugins": [
@@ -43,3 +53,12 @@ During the next release `auto` will update your compatibility map with the new i
 Your plugin might not be on the registry yet but you might still want to work on it and makes releases.
 If the directory where `auto` looks for your distribution files has a `.zip` file in it, that file will also get uploaded to the release.
 This way you can direct users in your `README.md` to manually install the plugin with the zip file.
+
+```txt
+📜 main.js
+📜 styles.css
+📜.autorc
+📜manifest.json
+📜versions.json
+📜my-plugin.zip
+```

--- a/packages/auto-plugin-obsidian/src/index.ts
+++ b/packages/auto-plugin-obsidian/src/index.ts
@@ -31,9 +31,12 @@ export default class ObsidianPlugin implements IPlugin {
   private readonly manifest: string;
   /** Path to the plugin-name.zip for manual installs of the plugin */
   private readonly zip?: string;
+  /** Directory with distribution files */
+  private readonly dir?: string;
 
   /** Initialize the plugin with it's options */
-  constructor({dir = process.cwd()}: IObsidianPluginOptions = {}) {
+  constructor({ dir = process.cwd() }: IObsidianPluginOptions = {}) {
+    this.dir = dir;
     this.styles = path.join(dir, "style.css");
     this.main = path.join(dir, "main.js");
     this.manifest = path.join(process.cwd(), "manifest.json");
@@ -69,7 +72,7 @@ export default class ObsidianPlugin implements IPlugin {
         auto.logger.log.error(`Could not find file "${this.manifest}"`);
         process.exit(1);
       }
-    })
+    });
 
     auto.hooks.version.tapPromise(
       this.name,
@@ -103,6 +106,10 @@ export default class ObsidianPlugin implements IPlugin {
 
         fs.writeFileSync(this.manifest, JSON.stringify(manifest, null, 2));
         await execPromise("git", ["add", this.manifest]);
+
+        if (this.dir !== process.cwd()) {
+          fs.copyFileSync(this.manifest, this.dir);
+        }
 
         // Update the versions.json
         const versionsPath = path.join(__dirname, "../versions.json");


### PR DESCRIPTION
Previously the files in the dist folder would be wrong, and the zip a user would create is wrong. Now that we do the zipping it works better.