### PR TITLE
correct copy usage

### DIFF
--- a/packages/auto-plugin-obsidian/src/index.ts
+++ b/packages/auto-plugin-obsidian/src/index.ts
@@ -110,7 +110,7 @@ export default class ObsidianPlugin implements IPlugin {
         await execPromise("git", ["add", this.manifest]);
 
         if (this.dir !== process.cwd()) {
-          fs.copyFileSync(this.manifest, this.dir);
+          fs.copyFileSync(this.manifest, path.join(this.dir, "manifest.json"));
         }
 
         // Update the versions.json


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install auto-plugin-obsidian@0.0.3-canary.11.8816ce0.0
  npm install obsidian-plugin-utils@0.0.5-canary.11.8816ce0.0
  # or 
  yarn add auto-plugin-obsidian@0.0.3-canary.11.8816ce0.0
  yarn add obsidian-plugin-utils@0.0.5-canary.11.8816ce0.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
