### PR TITLE
fix versions.json lookup and verification

### DIFF
--- a/packages/auto-plugin-obsidian/src/index.ts
+++ b/packages/auto-plugin-obsidian/src/index.ts
@@ -114,7 +114,7 @@ export default class ObsidianPlugin implements IPlugin {
         }
 
         // Update the versions.json
-        const versionsPath = path.join(__dirname, "../versions.json");
+        const versionsPath = path.join(process.cwd(), "../versions.json");
         const versions = JSON.parse(fs.readFileSync(versionsPath, "utf-8"));
 
         if (versions[lastVersion] !== manifest.minAppVersion) {


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install auto-plugin-obsidian@0.0.3-canary.12.1c70965.0
  npm install obsidian-plugin-utils@0.0.5-canary.12.1c70965.0
  # or 
  yarn add auto-plugin-obsidian@0.0.3-canary.12.1c70965.0
  yarn add obsidian-plugin-utils@0.0.5-canary.12.1c70965.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
