### PR TITLE
fix versions.json updates

### DIFF
--- a/packages/auto-plugin-obsidian/src/index.ts
+++ b/packages/auto-plugin-obsidian/src/index.ts
@@ -13,7 +13,7 @@ import * as semver from "semver";
 import * as t from "io-ts";
 
 const styleFileName = "styles.css";
-const mainFileName = 'main.js';
+const mainFileName = "main.js";
 const manifestFileName = "manifest.json";
 
 const pluginOptions = t.partial({
@@ -127,8 +127,10 @@ export default class ObsidianPlugin implements IPlugin {
 
         // Update the versions.json
         const versions = JSON.parse(fs.readFileSync(this.versions, "utf-8"));
+        const versionKeys = Object.keys(versions);
+        const lastChangedVersion = versionKeys[versionKeys.length - 1];
 
-        if (versions[lastVersion] !== manifest.minAppVersion) {
+        if (versions[lastChangedVersion] !== manifest.minAppVersion) {
           versions[manifest.version] = manifest.minAppVersion;
 
           const newVersions = JSON.stringify(versions, null, 2);


### PR DESCRIPTION
Since it was using the previous version it would update the file every other time. I know key order might not be consistent, but i've never experienced that