### PR TITLE
Add typescript types to obsidian-utils

### DIFF
--- a/packages/obsidian-utils/build.js
+++ b/packages/obsidian-utils/build.js
@@ -1,0 +1,11 @@
+const esbuild = require("esbuild");
+
+esbuild.build({
+  entryPoints: ["src/index.ts"],
+  bundle: true,
+  platform: "node",
+  external: ["obsidian"],
+  format: "cjs",
+  outfile: "lib/index.js",
+  mainFields: ["module", "main"],
+});

--- a/packages/obsidian-utils/package.json
+++ b/packages/obsidian-utils/package.json
@@ -12,7 +12,7 @@
   "author": "Justin Bennett <zephraph@gmail.com>",
   "homepage": "https://github.com/zephraph/obsidian-tools#readme",
   "license": "MIT",
-  "main": "./lib/obsidian-plugin-tools.js",
+  "main": "./lib/index.js",
   "directories": {
     "lib": "lib",
     "test": "__tests__"
@@ -25,12 +25,15 @@
     "url": "git+https://github.com/zephraph/obsidian-tools.git"
   },
   "scripts": {
-    "build": "esbuild --bundle --platform=node --external:obsidian --format=cjs --outfile=\"lib/obsidian-plugin-tools.js\" src/index.ts"
+    "prebuild": "rm -rf ./lib",
+    "build": "node build",
+    "postbuild": "tsc"
   },
   "bugs": {
     "url": "https://github.com/zephraph/obsidian-tools/issues"
   },
   "devDependencies": {
+    "@types/date-fns": "^2.6.0",
     "@types/node": "^14.14.28",
     "esbuild": "^0.8.49",
     "obsidian": "https://github.com/obsidianmd/obsidian-api/tarball/master",

--- a/packages/obsidian-utils/src/registry.ts
+++ b/packages/obsidian-utils/src/registry.ts
@@ -1,4 +1,4 @@
-import { isBefore, subMinutes } from "date-fns/esm";
+import { isBefore, subMinutes } from "date-fns";
 import { failIf, to } from "./utils";
 import log from "./log";
 

--- a/packages/obsidian-utils/src/utils.ts
+++ b/packages/obsidian-utils/src/utils.ts
@@ -10,9 +10,19 @@ export const fileStats = promisify(fs.stat);
 export const readJSON = (filePath: string) =>
   read(filePath, "utf-8").then((contents) => JSON.parse(contents));
 
-export const failIf = (condition: boolean, message: string) => {
+export function failIfNotDefined<T = any>(
+  condition: T | null | undefined | false | 0,
+  message: string
+): asserts condition is T {
+  if (!condition) throw new Error(message);
+}
+
+export function failIf(
+  condition: any,
+  message: string
+): asserts condition is false | null | undefined | 0 {
   if (condition) throw new Error(message);
-};
+}
 
 export const to = <T>(p: Promise<T>) => {
   return p.then((v) => [null, v]).catch((e) => [e, null]) as
@@ -24,17 +34,25 @@ export const to = <T>(p: Promise<T>) => {
  * Converts a web fetch response to a node readable stream
  */
 const resToReadable = (res: Response) => {
+  failIfNotDefined(res.body, "Response has no body");
   const reader = res.body.getReader();
   const readable = new Readable();
   readable._read = async () => {
     const { done, value } = await reader.read();
-    readable.push(done ? null : Buffer.from(value));
+    if (value) readable.push(done ? null : Buffer.from(value));
   };
   return readable;
 };
 
-export const toReadFromPath = (...pathParts: string[]) =>
-  to(read(path.join(...pathParts), "utf-8"));
+export const toRead = (...pathParts: string[]) =>
+  to<string>(read(path.join(...pathParts), "utf-8"));
+
+export const toReadJSON = <T>(...pathParts: string[]) =>
+  to<T>(
+    read(path.join(...pathParts), "utf-8").then((content) =>
+      JSON.parse(content)
+    )
+  );
 
 export const fetchJSON = (...args: Parameters<typeof fetch>) =>
   fetch(...args).then((res) => res.json());

--- a/packages/obsidian-utils/tsconfig.json
+++ b/packages/obsidian-utils/tsconfig.json
@@ -1,0 +1,72 @@
+{
+  "compilerOptions": {
+    /* Visit https://aka.ms/tsconfig.json to read more about this file */
+
+    "emitDeclarationOnly": true,
+    "declaration": true,
+    /* Basic Options */
+    // "incremental": true,                   /* Enable incremental compilation */
+    "target": "ES2018",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
+    "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */
+    // "lib": [],                             /* Specify library files to be included in the compilation. */
+    // "allowJs": true,                       /* Allow javascript files to be compiled. */
+    // "checkJs": true,                       /* Report errors in .js files. */
+    // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
+    // "declaration": true,                   /* Generates corresponding '.d.ts' file. */
+    // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
+    // "sourceMap": true,                     /* Generates corresponding '.map' file. */
+    "outFile": "./lib/index",                       /* Concatenate and emit output to single file. */
+    // "outDir": "./lib",                        /* Redirect output structure to the directory. */
+    // "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
+    // "composite": true,                     /* Enable project compilation */
+    // "tsBuildInfoFile": "./",               /* Specify file to store incremental compilation information */
+    // "removeComments": true,                /* Do not emit comments to output. */
+    // "noEmit": true,                        /* Do not emit outputs. */
+    // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
+    // "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
+    // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
+
+    /* Strict Type-Checking Options */
+    "strict": true,                           /* Enable all strict type-checking options. */
+    // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
+    // "strictNullChecks": true,              /* Enable strict null checks. */
+    // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
+    // "strictBindCallApply": true,           /* Enable strict 'bind', 'call', and 'apply' methods on functions. */
+    // "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */
+    // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
+    // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
+
+    /* Additional Checks */
+    // "noUnusedLocals": true,                /* Report errors on unused locals. */
+    // "noUnusedParameters": true,            /* Report errors on unused parameters. */
+    // "noImplicitReturns": true,             /* Report error when not all code paths in function return a value. */
+    // "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
+    // "noUncheckedIndexedAccess": true,      /* Include 'undefined' in index signature results */
+
+    /* Module Resolution Options */
+    "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+    // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
+    // "paths": { },                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
+    // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
+    // "typeRoots": [],                       /* List of folders to include type definitions from. */
+    // "types": [],                           /* Type declaration files to be included in compilation. */
+    // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
+    "esModuleInterop": true,                  /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+    // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
+    // "allowUmdGlobalAccess": true,          /* Allow accessing UMD globals from modules. */
+
+    /* Source Map Options */
+    // "sourceRoot": "",                      /* Specify the location where debugger should locate TypeScript files instead of source locations. */
+    // "mapRoot": "",                         /* Specify the location where debugger should locate map files instead of generated locations. */
+    // "inlineSourceMap": true,               /* Emit a single file with source maps instead of having a separate file. */
+    // "inlineSources": true,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
+
+    /* Experimental Options */
+    // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
+    // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
+
+    /* Advanced Options */
+    "skipLibCheck": true,                     /* Skip type checking of declaration files. */
+    "forceConsistentCasingInFileNames": true  /* Disallow inconsistently-cased references to the same file. */
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1249,6 +1249,13 @@
   resolved "https://registry.yarnpkg.com/@types/command-line-usage/-/command-line-usage-5.0.1.tgz#99424950da567ba67b6b65caee57ff03c4e751ec"
   integrity sha512-/xUgezxxYePeXhg5S04hUjxG9JZi+rJTs1+4NwpYPfSaS7BeDa6tVJkH6lN9Cb6rl8d24Fi2uX0s0Ngg2JT6gg==
 
+"@types/date-fns@^2.6.0":
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/@types/date-fns/-/date-fns-2.6.0.tgz#b062ca46562002909be0c63a6467ed173136acc1"
+  integrity sha1-sGLKRlYgApCb4MY6ZGftFzE2rME=
+  dependencies:
+    date-fns "*"
+
 "@types/debug@^4.1.5":
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/@types/debug/-/debug-4.1.5.tgz#b14efa8852b7768d898906613c23f688713e02cd"
@@ -2362,7 +2369,7 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
-date-fns@^2.17.0:
+date-fns@*, date-fns@^2.17.0:
   version "2.17.0"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.17.0.tgz#afa55daea539239db0a64e236ce716ef3d681ba1"
   integrity sha512-ZEhqxUtEZeGgg9eHNSOAJ8O9xqSgiJdrL0lzSSfMF54x6KXWJiOH/xntSJ9YomJPrYH/p08t6gWjGWq1SDJlSA==


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install auto-plugin-obsidian@0.1.4-canary.19.7a6220d.0
  npm install obsidian-utils@0.1.1-canary.19.7a6220d.0
  # or 
  yarn add auto-plugin-obsidian@0.1.4-canary.19.7a6220d.0
  yarn add obsidian-utils@0.1.1-canary.19.7a6220d.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
