### PR TITLE
Fix `obsidian-utils` types

### DIFF
--- a/packages/obsidian-utils/tsconfig.json
+++ b/packages/obsidian-utils/tsconfig.json
@@ -15,8 +15,8 @@
     // "declaration": true,                   /* Generates corresponding '.d.ts' file. */
     // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
     // "sourceMap": true,                     /* Generates corresponding '.map' file. */
-    "outFile": "./lib/index",                       /* Concatenate and emit output to single file. */
-    // "outDir": "./lib",                        /* Redirect output structure to the directory. */
+    // "outFile": "./lib/index",                       /* Concatenate and emit output to single file. */
+    "outDir": "./lib",                        /* Redirect output structure to the directory. */
     // "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
     // "composite": true,                     /* Enable project compilation */
     // "tsBuildInfoFile": "./",               /* Specify file to store incremental compilation information */


### PR DESCRIPTION
The types weren't working due to the outfile property not being supported by esm or commonjs. Changing it to dist generates multiple files, but it at least works. 