### PR TITLE
Export utils, update findVault to optionally take a vaultPath

### DIFF
--- a/packages/obsidian-utils/src/index.ts
+++ b/packages/obsidian-utils/src/index.ts
@@ -2,3 +2,4 @@ export * from "./install";
 export * from "./readFromDisk";
 export * from "./registry";
 export * from "./vault";
+export * as utils from "./utils";

--- a/packages/obsidian-utils/src/vault.ts
+++ b/packages/obsidian-utils/src/vault.ts
@@ -3,12 +3,28 @@ import path from "path";
 import fs from "fs";
 import { to, readJSON, failIf } from "./utils";
 
+interface ObsidianVaultDefinition {
+  path: string;
+  ts: number;
+  open?: true;
+}
+
 interface Vault {
   name: string;
   path: string;
 }
 
-export const findVault = async (): Promise<Vault[]> => {
+const getVaultFromPath = (vaultPath: string): Vault => {
+  return {
+    name: path.basename(vaultPath),
+    path: vaultPath,
+  };
+};
+
+export const findVault = async (vaultPath?: string): Promise<Vault[]> => {
+  if (vaultPath && fs.existsSync(vaultPath)) {
+    return [getVaultFromPath(vaultPath)];
+  }
   const home = os.homedir();
   let obsidianPath = "";
   switch (os.platform()) {
@@ -41,8 +57,7 @@ export const findVault = async (): Promise<Vault[]> => {
     `Could not read obsidian.json: ${obsidianReadError}\nVaults won't be retrievable`
   );
 
-  return Object.values(obsidian.vaults).map((vault: any) => ({
-    path: vault.path,
-    name: path.basename(vault.path),
-  }));
+  return Object.values<ObsidianVaultDefinition>(obsidian.vaults).map<Vault>(
+    (vault) => getVaultFromPath(vault.path)
+  );
 };


### PR DESCRIPTION
Two small things. The utils module is actually useful in other places so I'm exporting that (even if it's a bit  redundant). 

Also enabling `findVault` to optionally take a vault path. If one is given, it'll try to resolve that first and just return that path, otherwise it'll still try to infer it from the fs. Generally this is just to make the cli work of finding a vault easier. 