### PR TITLE
Set node compat for utils to node v12

### DIFF
--- a/packages/obsidian-utils/build.js
+++ b/packages/obsidian-utils/build.js
@@ -8,4 +8,5 @@ esbuild.build({
   format: "cjs",
   outfile: "lib/index.js",
   mainFields: ["module", "main"],
+  target: "es2019",
 });

--- a/packages/obsidian-utils/package.json
+++ b/packages/obsidian-utils/package.json
@@ -2,6 +2,9 @@
   "name": "obsidian-utils",
   "version": "0.5.0",
   "description": "A collection of utilities for interacting with or getting information on obsidian plugins",
+  "engines": {
+    "node": ">=12.0.0"
+  },
   "keywords": [
     "obsidian",
     "obsidian.md",


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install obsidian-plugin-cli@0.0.4-canary.25.5550cfa.0
  npm install obsidian-utils@0.5.1-canary.25.5550cfa.0
  # or 
  yarn add obsidian-plugin-cli@0.0.4-canary.25.5550cfa.0
  yarn add obsidian-utils@0.5.1-canary.25.5550cfa.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
