### PR TITLE
Update obsidian-plugin-cli to use new utils

### DIFF
--- a/packages/obsidian-plugin-cli/package.json
+++ b/packages/obsidian-plugin-cli/package.json
@@ -27,7 +27,7 @@
     "@types/update-notifier": "^5.0.0",
     "globby": "^10",
     "ts-node": "^8",
-    "typescript": "^3.3"
+    "typescript": "^4.2.2"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/packages/obsidian-plugin-cli/src/commands/dev.ts
+++ b/packages/obsidian-plugin-cli/src/commands/dev.ts
@@ -109,7 +109,7 @@ export default class Dev extends Command {
             message: "Enter the path to your vault",
             type: "text",
             validate: (v) =>
-              isVault(v) || `${v} is not a valid vault, try again`,
+              vault.isVault(v) || `${v} is not a valid vault, try again`,
           });
           if (!selectedVaultPath) this.error(`No vault selected`);
           vaultPath = selectedVaultPath;

--- a/yarn.lock
+++ b/yarn.lock
@@ -6998,15 +6998,15 @@ typescript-memoize@^1.0.0-alpha.3:
   resolved "https://registry.yarnpkg.com/typescript-memoize/-/typescript-memoize-1.0.0.tgz#ad3b0e7e5a411ca234be123f913a2a31302b7eb6"
   integrity sha512-B1eufjs/mGzHqoGeI1VT/dnSBoZr2v3i3/Wm8NmdxlZflyVdleE8wO0QwUuj4NfundD7T5nU3I7HSKp/5BD9og==
 
-typescript@^3.3:
-  version "3.9.9"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.9.tgz#e69905c54bc0681d0518bd4d587cc6f2d0b1a674"
-  integrity sha512-kdMjTiekY+z/ubJCATUPlRDl39vXYiMV9iyeMuEuXZh2we6zz80uovNN2WlAxmmdE/Z/YQe+EbOEXB5RHEED3w==
-
 typescript@^4.1.5:
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.5.tgz#123a3b214aaff3be32926f0d8f1f6e704eb89a72"
   integrity sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA==
+
+typescript@^4.2.2:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.2.2.tgz#1450f020618f872db0ea17317d16d8da8ddb8c4c"
+  integrity sha512-tbb+NVrLfnsJy3M59lsDgrzWIflR4d4TIUjz+heUnHZwdF7YsrMTKoRERiIvI2lvBG95dfpLxB21WZhys1bgaQ==
 
 typical@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
Makes an update so that the cli tool is using the new utils. 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install obsidian-plugin-cli@0.1.2-canary.29.70caa43.0
  npm install obsidian-utils@0.5.3-canary.29.70caa43.0
  # or 
  yarn add obsidian-plugin-cli@0.1.2-canary.29.70caa43.0
  yarn add obsidian-utils@0.5.3-canary.29.70caa43.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
