### PR TITLE
Support esbuild config files, change esbuild-override to esbuild-config

### DIFF
--- a/packages/obsidian-plugin-cli/README.md
+++ b/packages/obsidian-plugin-cli/README.md
@@ -2,20 +2,24 @@
 
 A CLI tool to make building an obsidian plugin simple
 
+**NOTE** This is _alpha_ software and there _will_ be breaking changes. It'll be stable once 1.0 is released.
+
 [![oclif](https://img.shields.io/badge/cli-oclif-brightgreen.svg)](https://oclif.io)
 [![Version](https://img.shields.io/npm/v/obsidian-plugin-cli.svg)](https://npmjs.org/package/obsidian-plugin-cli)
 [![Downloads/week](https://img.shields.io/npm/dw/obsidian-plugin-cli.svg)](https://npmjs.org/package/obsidian-plugin-cli)
 [![License](https://img.shields.io/npm/l/obsidian-plugin-cli.svg)](https://github.com/zephraph/obsidian-tools/blob/master/package.json)
 
 <!-- toc -->
-* [obsidian-plugin-cli](#obsidian-plugin-cli)
-* [Usage](#usage)
-* [Commands](#commands)
+
+- [obsidian-plugin-cli](#obsidian-plugin-cli)
+- [Usage](#usage)
+- [Commands](#commands)
 <!-- tocstop -->
 
 # Usage
 
 <!-- usage -->
+
 ```sh-session
 $ npm install -g obsidian-plugin-cli
 $ obsidian-plugin COMMAND
@@ -27,14 +31,16 @@ USAGE
   $ obsidian-plugin COMMAND
 ...
 ```
+
 <!-- usagestop -->
 
 # Commands
 
 <!-- commands -->
-* [`obsidian-plugin build [ENTRYPOINT]`](#obsidian-plugin-build-entrypoint)
-* [`obsidian-plugin dev [ENTRYPOINT]`](#obsidian-plugin-dev-entrypoint)
-* [`obsidian-plugin help [COMMAND]`](#obsidian-plugin-help-command)
+
+- [`obsidian-plugin build [ENTRYPOINT]`](#obsidian-plugin-build-entrypoint)
+- [`obsidian-plugin dev [ENTRYPOINT]`](#obsidian-plugin-dev-entrypoint)
+- [`obsidian-plugin help [COMMAND]`](#obsidian-plugin-help-command)
 
 ## `obsidian-plugin build [ENTRYPOINT]`
 
@@ -75,11 +81,11 @@ OPTIONS
 
 DESCRIPTION
   If --vault-path is not specified, this command will try to intelligently determine where your vaults are located.
-  If it's able to locate your vaults, you'll be given the option to select which vault you'd like to develop against. 
-  If, however, --no-prompts is passed it will assume the last opened vault (if one is found) will be the vault to 
-  develop 
-  against. If that's not the behavior you desire, ensure to pass the explicit path to the vault you want to develop 
-  against 
+  If it's able to locate your vaults, you'll be given the option to select which vault you'd like to develop against.
+  If, however, --no-prompts is passed it will assume the last opened vault (if one is found) will be the vault to
+  develop
+  against. If that's not the behavior you desire, ensure to pass the explicit path to the vault you want to develop
+  against
   with --vault-path.
 ```
 
@@ -101,4 +107,5 @@ OPTIONS
 ```
 
 _See code: [@oclif/plugin-help](https://github.com/oclif/plugin-help/blob/v3.2.2/src/commands/help.ts)_
+
 <!-- commandsstop -->

--- a/packages/obsidian-plugin-cli/package.json
+++ b/packages/obsidian-plugin-cli/package.json
@@ -12,6 +12,7 @@
     "@oclif/config": "^1",
     "@oclif/plugin-help": "^3",
     "ansi-colors": "^4.1.1",
+    "cosmiconfig": "^7.0.0",
     "dedent": "^0.7.0",
     "esbuild": "^0.8.48",
     "obsidian-utils": "^0.8.0",

--- a/packages/obsidian-plugin-cli/src/build.ts
+++ b/packages/obsidian-plugin-cli/src/build.ts
@@ -1,0 +1,11 @@
+import esbuild from "esbuild";
+
+export const build = (options: esbuild.BuildOptions) => {
+  return esbuild.build({
+    bundle: true,
+    platform: "node",
+    external: ["obsidian"],
+    format: "cjs",
+    ...options,
+  });
+};

--- a/packages/obsidian-plugin-cli/src/build.ts
+++ b/packages/obsidian-plugin-cli/src/build.ts
@@ -6,6 +6,7 @@ export const build = (options: esbuild.BuildOptions) => {
     platform: "node",
     external: ["obsidian"],
     format: "cjs",
+    mainFields: ["browser", "module", "main"],
     ...options,
   });
 };

--- a/packages/obsidian-plugin-cli/src/commands/build.ts
+++ b/packages/obsidian-plugin-cli/src/commands/build.ts
@@ -2,15 +2,17 @@ import { Command, flags } from "@oclif/command";
 import path from "path";
 import fs from "fs";
 import { build } from "../build";
+import { getConfig } from "../config";
+import { to } from "obsidian-utils";
 
 export default class Build extends Command {
   static description = "builds plugin for release";
   static flags = {
     help: flags.help({ char: "h" }),
-    ["esbuild-override"]: flags.string({
+    ["esbuild-config"]: flags.string({
       char: "e",
       description:
-        "path to a JSON file over esbuild options to enhance/override the current build",
+        "path to a config file containing esbuild options to apply to the build",
     }),
     ["output-dir"]: flags.string({
       char: "o",
@@ -24,21 +26,19 @@ export default class Build extends Command {
   async run() {
     const { args, flags } = this.parse(Build);
     const {
-      ["esbuild-override"]: esbuildOverride,
+      ["esbuild-config"]: esbuildConfigPath,
       ["output-dir"]: outputDir,
     } = flags;
 
-    let esbuildConfig = {};
-    if (esbuildOverride) {
-      if (!esbuildOverride.endsWith(".json")) {
-        this.log("Expected esbuildOverride to be json file");
-        process.exit(1);
-      }
-      esbuildConfig = JSON.parse(fs.readFileSync(esbuildOverride, "utf-8"));
+    const [configError, esbuildConfig] = await to(
+      getConfig(args.entryPoint, esbuildConfigPath)
+    );
+
+    if (configError) {
+      this.error(configError);
     }
 
     await build({
-      entryPoints: [args.entryPoint],
       outfile: path.join(outputDir, "main.js"),
       ...esbuildConfig,
     });

--- a/packages/obsidian-plugin-cli/src/commands/build.ts
+++ b/packages/obsidian-plugin-cli/src/commands/build.ts
@@ -1,7 +1,7 @@
 import { Command, flags } from "@oclif/command";
 import path from "path";
-import * as esbuild from "esbuild";
 import fs from "fs";
+import { build } from "../build";
 
 export default class Build extends Command {
   static description = "builds plugin for release";
@@ -37,13 +37,9 @@ export default class Build extends Command {
       esbuildConfig = JSON.parse(fs.readFileSync(esbuildOverride, "utf-8"));
     }
 
-    esbuild.build({
+    await build({
       entryPoints: [args.entryPoint],
       outfile: path.join(outputDir, "main.js"),
-      bundle: true,
-      format: "cjs",
-      platform: "node",
-      external: ["obsidian"],
       ...esbuildConfig,
     });
 

--- a/packages/obsidian-plugin-cli/src/commands/dev.ts
+++ b/packages/obsidian-plugin-cli/src/commands/dev.ts
@@ -13,6 +13,7 @@ import {
   installPluginFromGithub,
 } from "obsidian-utils";
 import { build } from "../build";
+import { getConfig } from "../config";
 
 const localManifestPath = path.join(process.cwd(), "manifest.json");
 
@@ -38,7 +39,7 @@ export default class Dev extends Command {
   `;
   static flags = {
     help: flags.help({ char: "h" }),
-    ["esbuild-override"]: flags.string({
+    ["esbuild-config"]: flags.string({
       char: "e",
       description:
         "path to a JSON file over esbuild options to enhance/override the current build",
@@ -59,21 +60,17 @@ export default class Dev extends Command {
   async run() {
     const { args, flags } = this.parse(Dev);
     let {
-      ["esbuild-override"]: esbuildOverride,
+      ["esbuild-config"]: esbuildConfigPath,
       ["vault-path"]: vaultPath,
       ["no-prompts"]: noPrompts,
     } = flags;
 
-    if (!args.entryPoint) {
-      this.error("Must provide the path to a file to build");
-    }
+    const [configError, esbuildConfig] = await to(
+      getConfig(args.entryPoint, esbuildConfigPath)
+    );
 
-    let esbuildConfig = {};
-    if (esbuildOverride) {
-      if (!esbuildOverride.endsWith(".json")) {
-        this.error("Expected esbuildOverride to be json file");
-      }
-      esbuildConfig = JSON.parse(fs.readFileSync(esbuildOverride, "utf-8"));
+    if (configError) {
+      this.error(configError);
     }
 
     if (!fs.existsSync(localManifestPath)) {
@@ -201,7 +198,6 @@ export default class Dev extends Command {
     });
 
     await build({
-      entryPoints: [args.entryPoint],
       outfile: path.join(pluginPath, "main.js"),
       watch: true,
       ...esbuildConfig,

--- a/packages/obsidian-plugin-cli/src/commands/dev.ts
+++ b/packages/obsidian-plugin-cli/src/commands/dev.ts
@@ -1,6 +1,5 @@
 import { Command, flags } from "@oclif/command";
 import path from "path";
-import * as esbuild from "esbuild";
 import fs from "fs";
 import { promisify } from "util";
 import prompts from "prompts";
@@ -13,6 +12,7 @@ import {
   isPluginInstalled,
   installPluginFromGithub,
 } from "obsidian-utils";
+import { build } from "../build";
 
 const localManifestPath = path.join(process.cwd(), "manifest.json");
 
@@ -200,13 +200,9 @@ export default class Dev extends Command {
       }
     });
 
-    await esbuild.build({
+    await build({
       entryPoints: [args.entryPoint],
       outfile: path.join(pluginPath, "main.js"),
-      bundle: true,
-      format: "cjs",
-      platform: "node",
-      external: ["obsidian"],
       watch: true,
       ...esbuildConfig,
     });

--- a/packages/obsidian-plugin-cli/src/config.ts
+++ b/packages/obsidian-plugin-cli/src/config.ts
@@ -1,0 +1,24 @@
+import { BuildOptions } from "esbuild";
+import { cosmiconfig } from "cosmiconfig";
+
+export const getConfig = async (entryPoint: any, configPath?: string) => {
+  let esbuildConfig: BuildOptions;
+  const configFinder = cosmiconfig("esbuild");
+  if (configPath) {
+    const { config } = (await configFinder.load(configPath)) ?? {
+      config: {},
+    };
+    esbuildConfig = config;
+  } else {
+    const { config } = (await configFinder.search()) ?? { config: {} };
+    esbuildConfig = config;
+  }
+
+  if (!entryPoint && !esbuildConfig.entryPoints) {
+    throw new Error("Please provide the path to a file to build");
+  } else if (!entryPoint) {
+    return (esbuildConfig.entryPoints = [entryPoint]);
+  } else {
+    return esbuildConfig;
+  }
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2432,7 +2432,7 @@ core-util-is@1.0.2, core-util-is@~1.0.0:
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
   integrity sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=
 
-cosmiconfig@7.0.0:
+cosmiconfig@7.0.0, cosmiconfig@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-7.0.0.tgz#ef9b44d773959cae63ddecd122de23853b60f8d3"
   integrity sha512-pondGvTuVYDk++upghXJabWzL6Kxu6f26ljFw64Swq9v6sQPUL3EUlVDV56diOjpCayKihL6hVe8exIACU4XcA==


### PR DESCRIPTION
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install obsidian-plugin-cli@0.4.1-canary.32.b06f2ad.0
  # or 
  yarn add obsidian-plugin-cli@0.4.1-canary.32.b06f2ad.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->

## Release Notes

This release introduces the ability to automatically include config for esbuild without having to pass the option via the command line. All you need to do is create a `esbuild.config.json` (or any other format supported by [cosmiconfig](https://github.com/davidtheclark/cosmiconfig)) and it'll automatically be included in your build. You can still manually specify a path to the config using `--esbuild-config`. 

This release also updates the default resolution strategy that esbuild will use to find modules. The new order is `browser`, `module`, `main`.  You can learn more by reading esbuild's [main fields](https://esbuild.github.io/api/#main-fields) docs and you can also override this option by specifying you're own `mainFields` options in your esbuild config. 

💥 BREAKING CHANGES 💥 

The `--esbuild-override` command is now `--esbuild-config`