### PR TITLE
Fix esbuild error

### DIFF
--- a/packages/obsidian-plugin-cli/src/build.ts
+++ b/packages/obsidian-plugin-cli/src/build.ts
@@ -1,4 +1,4 @@
-import esbuild from "esbuild";
+import * as esbuild from "esbuild";
 
 export const build = (options: esbuild.BuildOptions) => {
   return esbuild.build({


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install obsidian-plugin-cli@0.4.2-canary.33.fa40b8b.0
  # or 
  yarn add obsidian-plugin-cli@0.4.2-canary.33.fa40b8b.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
