### PR TITLE
Ensure entrypoint gets properly passed

### DIFF
--- a/packages/obsidian-plugin-cli/src/config.ts
+++ b/packages/obsidian-plugin-cli/src/config.ts
@@ -14,11 +14,14 @@ export const getConfig = async (entryPoint: any, configPath?: string) => {
     esbuildConfig = config;
   }
 
-  if (!entryPoint && !esbuildConfig.entryPoints) {
-    throw new Error("Please provide the path to a file to build");
-  } else if (!entryPoint) {
-    return (esbuildConfig.entryPoints = [entryPoint]);
-  } else {
+  if (entryPoint) {
+    esbuildConfig.entryPoints = [entryPoint];
     return esbuildConfig;
   }
+
+  if (!esbuildConfig.entryPoints) {
+    throw new Error("Please provide the path to a file to build");
+  }
+
+  return esbuildConfig;
 };


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install obsidian-plugin-cli@0.4.3-canary.34.b5a28bb.0
  # or 
  yarn add obsidian-plugin-cli@0.4.3-canary.34.b5a28bb.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
