### PR TITLE
Minify output of "obsidian-plugin build"

### DIFF
--- a/packages/obsidian-plugin-cli/src/commands/build.ts
+++ b/packages/obsidian-plugin-cli/src/commands/build.ts
@@ -40,6 +40,7 @@ export default class Build extends Command {
 
     await build({
       outfile: path.join(outputDir, "main.js"),
+      minify: true,
       ...esbuildConfig,
     });
 


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install obsidian-plugin-cli@0.4.4-canary.35.f610459.0
  # or 
  yarn add obsidian-plugin-cli@0.4.4-canary.35.f610459.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
