### PR TITLE
Initial, working `create-obsidian-plugin`

### DIFF
--- a/packages/create-obsidian-plugin/bin/run
+++ b/packages/create-obsidian-plugin/bin/run
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+
+require("../lib");

--- a/packages/create-obsidian-plugin/bin/run.cmd
+++ b/packages/create-obsidian-plugin/bin/run.cmd
@@ -1,0 +1,3 @@
+@echo off
+
+node "%~dp0\run" %*

--- a/packages/create-obsidian-plugin/package.json
+++ b/packages/create-obsidian-plugin/package.json
@@ -24,7 +24,8 @@
     "url": "git+https://github.com/zephraph/obsidian-tools.git"
   },
   "scripts": {
-    "build": "esbuild --bundle --platform=node --external:obsidian --format=cjs --outfile=\"lib/create-obsidian-plugin.js\" src/index.ts"
+    "build": "tsc",
+    "echo": "node test.js"
   },
   "bugs": {
     "url": "https://github.com/zephraph/obsidian-tools/issues"
@@ -37,5 +38,10 @@
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
     "access": "public"
+  },
+  "dependencies": {
+    "ejs": "^3.1.6",
+    "execa": "^5.0.0",
+    "prompts": "^2.4.0"
   }
 }

--- a/packages/create-obsidian-plugin/package.json
+++ b/packages/create-obsidian-plugin/package.json
@@ -24,14 +24,19 @@
     "url": "git+https://github.com/zephraph/obsidian-tools.git"
   },
   "scripts": {
-    "build": "tsc",
+    "prebuild": "rm -rf ./lib",
+    "build": "tsc && cp -R src/templates lib/templates",
+    "prestart": "yarn build",
+    "start": "./bin/run",
     "echo": "node test.js"
   },
   "bugs": {
     "url": "https://github.com/zephraph/obsidian-tools/issues"
   },
   "devDependencies": {
+    "@types/ejs": "^3.0.6",
     "@types/node": "^14.14.28",
+    "@types/prettier": "^2.2.2",
     "esbuild": "^0.8.49",
     "typescript": "^4.1.5"
   },
@@ -40,8 +45,11 @@
     "access": "public"
   },
   "dependencies": {
+    "ansi-colors": "^4.1.1",
+    "dedent": "^0.7.0",
     "ejs": "^3.1.6",
     "execa": "^5.0.0",
+    "prettier": "^2.2.1",
     "prompts": "^2.4.0"
   }
 }

--- a/packages/create-obsidian-plugin/src/index.ts
+++ b/packages/create-obsidian-plugin/src/index.ts
@@ -1,1 +1,41 @@
-throw new Error("Not yet implemented");
+import prompts from "prompts";
+
+interface PluginInfo {
+  id: string;
+  name: string;
+}
+
+prompts.override({
+  id: process.argv.slice(2).join("-").toLowerCase() || undefined,
+});
+
+(async () => {
+  const plugin = await prompts([
+    {
+      type: () => "text",
+      name: "id",
+      message: "Enter the plugin id",
+      validate: (text) =>
+        !text.includes(" ") || "Plugin ID must not contain spaces",
+    },
+    {
+      type: "text",
+      name: "name",
+      message: "Enter the plugin name",
+      // @ts-ignore
+      initial: (prev) =>
+        prev
+          .replace("obsidian-plugin", "")
+          .split("-")
+          .filter((x: string) => x)
+          .map((word: string) => word[0].toUpperCase() + word.slice(1))
+          .join(" "),
+    },
+    {
+      type: "text",
+      name: "description",
+      message: "Plugin description",
+    },
+  ]);
+  console.log(plugin);
+})();

--- a/packages/create-obsidian-plugin/src/index.ts
+++ b/packages/create-obsidian-plugin/src/index.ts
@@ -1,41 +1,68 @@
-import prompts from "prompts";
+import { PluginInfo, prompt } from "./plugin";
+import { renderFile } from "ejs";
+import path from "path";
+import { write, mkdir } from "./utils/fs";
+import { format } from "prettier";
+import { install, runCommandText } from "./utils/platform";
+import dedent from "dedent";
+import { green, cyan } from "ansi-colors";
+import fs from "fs";
 
-interface PluginInfo {
-  id: string;
-  name: string;
-}
+const newline = () => console.log();
 
-prompts.override({
-  id: process.argv.slice(2).join("-").toLowerCase() || undefined,
-});
+const makeWriteTemplate = (plugin: PluginInfo) => async (
+  name: string,
+  relativePathToProjectRoot = ""
+) => {
+  const content = await renderFile(
+    path.join(__dirname, "templates", `${name}.ejs`),
+    { plugin },
+    { rmWhitespace: true }
+  );
+  const destinationDir = path.join(
+    process.cwd(),
+    plugin.id,
+    relativePathToProjectRoot
+  );
+
+  if (!fs.existsSync(destinationDir)) {
+    await mkdir(destinationDir, { recursive: true });
+  }
+
+  await write(
+    path.join(destinationDir, name),
+    path.extname(name) !== "" ? format(content, { filepath: name }) : content
+  );
+};
+
+const pluginPath = (plugin: PluginInfo) => path.join(process.cwd(), plugin.id);
 
 (async () => {
-  const plugin = await prompts([
-    {
-      type: () => "text",
-      name: "id",
-      message: "Enter the plugin id",
-      validate: (text) =>
-        !text.includes(" ") || "Plugin ID must not contain spaces",
-    },
-    {
-      type: "text",
-      name: "name",
-      message: "Enter the plugin name",
-      // @ts-ignore
-      initial: (prev) =>
-        prev
-          .replace("obsidian-plugin", "")
-          .split("-")
-          .filter((x: string) => x)
-          .map((word: string) => word[0].toUpperCase() + word.slice(1))
-          .join(" "),
-    },
-    {
-      type: "text",
-      name: "description",
-      message: "Plugin description",
-    },
-  ]);
-  console.log(plugin);
+  let plugin = await prompt();
+  const writeTemplate = makeWriteTemplate(plugin);
+
+  console.log(`Creating a new obsidian plugin at ${green(`./${plugin.id}`)}`);
+
+  await writeTemplate("manifest.json");
+  await writeTemplate("package.json");
+  await writeTemplate("main.ts", "src");
+  await writeTemplate(".gitignore");
+
+  console.log("Installing plugin dependencies, this may take a little while.");
+
+  const installProcess = install(pluginPath(plugin));
+  installProcess.stdout?.pipe(process.stdout);
+
+  await installProcess;
+
+  newline();
+
+  console.log(dedent`
+    To get started developing on your plugin run
+
+      ${cyan(`cd ${plugin.id}`)}
+      ${cyan(runCommandText("dev"))}
+  `);
+
+  newline();
 })();

--- a/packages/create-obsidian-plugin/src/plugin.ts
+++ b/packages/create-obsidian-plugin/src/plugin.ts
@@ -1,0 +1,93 @@
+import prompts from "prompts";
+import fs from "fs";
+import { yellow, green, dim, reset } from "ansi-colors";
+import dedent from "dedent";
+import { cmd } from "./utils/platform";
+
+const capitalize = (word: string) => word[0].toUpperCase() + word.slice(1);
+const empty = (v: any) => Boolean(v);
+
+const validatePluginID = (pluginID: string, includeReason = false) => {
+  if (fs.existsSync(pluginID) && fs.lstatSync(pluginID).isDirectory()) {
+    return includeReason
+      ? dedent`
+          A directory ${green(pluginID)} already exists
+
+          Either choose a different id or press ${yellow(
+            `${cmd} + C`
+          )} to cancel`
+      : false;
+  }
+  return (
+    !pluginID.includes(" ") ||
+    (includeReason ? `The id must not contain spaces` : false)
+  );
+};
+
+export interface PluginInfo {
+  id: string;
+  name: string;
+  className: string;
+  description: string;
+  author: string;
+  authorUrl: string;
+}
+
+export async function prompt(): Promise<PluginInfo> {
+  const defaultID = process.argv.slice(2).join("-").toLowerCase();
+  prompts.override({
+    id: defaultID && validatePluginID(defaultID) ? defaultID : undefined,
+  });
+  const answers = await prompts(
+    [
+      {
+        type: () => "text",
+        name: "id",
+        message: `Enter the plugin id ${reset(dim("(lowercase, no spaces)"))}`,
+        initial: defaultID,
+        format: (text) => text.trim().toLowerCase(),
+        validate: (text) => validatePluginID(text, true),
+      },
+      {
+        type: "text",
+        name: "name",
+        message: "Enter the plugin name",
+        // @ts-ignore
+        initial: (prev) =>
+          prev
+            .replace("obsidian-plugin", "")
+            .split("-")
+            .filter((x: string) => x)
+            .map(capitalize)
+            .join(" "),
+      },
+      {
+        type: "text",
+        name: "description",
+        message: "Write a short description of what the plugin does",
+      },
+      {
+        type: "text",
+        name: "author",
+        message:
+          "Enter your name or username you'd like the plugin to show as the author",
+        initial: process.env.npm_config_init_author_name,
+      },
+      {
+        type: "text",
+        name: "authorUrl",
+        message: "Add your website or social media account (optional)",
+      },
+    ],
+    {
+      onCancel() {
+        process.exit();
+      },
+    }
+  );
+
+  return {
+    ...answers,
+    className: answers.name.split(" ").filter(empty).map(capitalize).join(""),
+  };
+}

--- a/packages/create-obsidian-plugin/src/templates/.gitignore.ejs
+++ b/packages/create-obsidian-plugin/src/templates/.gitignore.ejs
@@ -1,0 +1,6 @@
+node_modules
+.env
+*-error.log
+package-lock.json
+yarn.lock
+.npmrc

--- a/packages/create-obsidian-plugin/src/templates/main.ts.ejs
+++ b/packages/create-obsidian-plugin/src/templates/main.ts.ejs
@@ -1,0 +1,123 @@
+import {
+  App,
+  Modal,
+  Notice,
+  Plugin,
+  PluginSettingTab,
+  Setting,
+} from "obsidian";
+
+interface <%= plugin.className %>Settings {
+  mySetting: string;
+}
+
+const DEFAULT_SETTINGS: <%= plugin.className %>Settings = {
+  mySetting: "default",
+};
+
+export default class <%= plugin.className %> extends Plugin {
+  settings: <%= plugin.className %>Settings;
+
+  async onload() {
+    console.log("loading plugin");
+
+    await this.loadSettings();
+
+    this.addRibbonIcon("dice", "Sample Plugin", () => {
+      new Notice("This is a notice!");
+    });
+
+    this.addStatusBarItem().setText("Status Bar Text");
+
+    this.addCommand({
+      id: "open-sample-modal",
+      name: "Open Sample Modal",
+      // callback: () => {
+      // 	console.log('Simple Callback');
+      // },
+      checkCallback: (checking: boolean) => {
+        let leaf = this.app.workspace.activeLeaf;
+        if (leaf) {
+          if (!checking) {
+            new SampleModal(this.app).open();
+          }
+          return true;
+        }
+        return false;
+      },
+    });
+
+    this.addSettingTab(new SampleSettingTab(this.app, this));
+
+    this.registerCodeMirror((cm: CodeMirror.Editor) => {
+      console.log("codemirror", cm);
+    });
+
+    this.registerDomEvent(document, "click", (evt: MouseEvent) => {
+      console.log("click", evt);
+    });
+
+    this.registerInterval(
+      window.setInterval(() => console.log("setInterval"), 5 * 60 * 1000)
+    );
+  }
+
+  onunload() {
+    console.log("unloading plugin");
+  }
+
+  async loadSettings() {
+    this.settings = Object.assign({}, DEFAULT_SETTINGS, await this.loadData());
+  }
+
+  async saveSettings() {
+    await this.saveData(this.settings);
+  }
+}
+
+class SampleModal extends Modal {
+  constructor(app: App) {
+    super(app);
+  }
+
+  onOpen() {
+    let { contentEl } = this;
+    contentEl.setText("Woah!");
+  }
+
+  onClose() {
+    let { contentEl } = this;
+    contentEl.empty();
+  }
+}
+
+class SampleSettingTab extends PluginSettingTab {
+  plugin: <%= plugin.className %>;
+
+  constructor(app: App, plugin: <%= plugin.className %>) {
+    super(app, plugin);
+    this.plugin = plugin;
+  }
+
+  display(): void {
+    let { containerEl } = this;
+
+    containerEl.empty();
+
+    containerEl.createEl("h2", { text: "Settings for my awesome plugin." });
+
+    new Setting(containerEl)
+      .setName("Setting #1")
+      .setDesc("It's a secret")
+      .addText((text) =>
+        text
+          .setPlaceholder("Enter your secret")
+          .setValue("")
+          .onChange(async (value) => {
+            console.log("Secret: " + value);
+            this.plugin.settings.mySetting = value;
+            await this.plugin.saveSettings();
+          })
+      );
+  }
+}

--- a/packages/create-obsidian-plugin/src/templates/manifest.json.ejs
+++ b/packages/create-obsidian-plugin/src/templates/manifest.json.ejs
@@ -1,0 +1,11 @@
+{
+  "id": "<%= plugin.id %>",
+  "name": "<%= plugin.name %>",
+  "description": "<%= plugin.description %>",
+  "author": "<%= plugin.author %>",
+  <% if (plugin.authorUrl) { %>
+    "authorUrl": "<%= plugin.authorUrl %>",
+  <% } %>
+  "minAppVersion": "0.11.0",
+  "version": "0.0.1"
+}

--- a/packages/create-obsidian-plugin/src/templates/package.json.ejs
+++ b/packages/create-obsidian-plugin/src/templates/package.json.ejs
@@ -1,7 +1,7 @@
 {
-  "name": "<%= props.name %>",
+  "name": "<%= plugin.id %>",
   "version": "0.0.1",
-  "description": "<%= props.description %>",
+  "description": "<%= plugin.description %>",
   "main": "lib/main.js",
   "scripts": {
     "build": "obsidian-plugin build src/main.ts",
@@ -9,7 +9,7 @@
   },
   "devDependencies": {
     "typescript": "^4.1.5",
-    "obsidian-plugin-cli": "<%= props.opcVersion %>",
+    "obsidian-plugin-cli": "^0.4.3",
     "obsidian": "obsidianmd/obsidian-api"
   }
 }

--- a/packages/create-obsidian-plugin/src/templates/package.json.ejs
+++ b/packages/create-obsidian-plugin/src/templates/package.json.ejs
@@ -1,0 +1,15 @@
+{
+  "name": "<%= props.name %>",
+  "version": "0.0.1",
+  "description": "<%= props.description %>",
+  "main": "lib/main.js",
+  "scripts": {
+    "build": "obsidian-plugin build src/main.ts",
+    "dev": "obsidian-plugin dev src/main.ts"
+  },
+  "devDependencies": {
+    "typescript": "^4.1.5",
+    "obsidian-plugin-cli": "<%= props.opcVersion %>",
+    "obsidian": "obsidianmd/obsidian-api"
+  }
+}

--- a/packages/create-obsidian-plugin/src/utils/async.ts
+++ b/packages/create-obsidian-plugin/src/utils/async.ts
@@ -1,0 +1,6 @@
+export const to = <T, U = Error>(
+  p: Promise<T>
+): Promise<[null, T] | [U, undefined]> =>
+  p
+    .then<[null, T]>((value) => [null, value])
+    .catch<[U, undefined]>((e: U) => [e, undefined]);

--- a/packages/create-obsidian-plugin/src/utils/fs.ts
+++ b/packages/create-obsidian-plugin/src/utils/fs.ts
@@ -1,0 +1,6 @@
+import { promisify } from "util";
+import fs from "fs";
+
+export const write = promisify(fs.writeFile);
+export const read = promisify(fs.readFile);
+export const mkdir = promisify(fs.mkdir);

--- a/packages/create-obsidian-plugin/src/utils/platform.ts
+++ b/packages/create-obsidian-plugin/src/utils/platform.ts
@@ -1,0 +1,25 @@
+import execa from "execa";
+
+export type Platform = typeof platforms[number] | false;
+const platforms = ["npm", "yarn/1", "yarn/2", "pnpm"] as const;
+export const detectPlatform = (): Platform => {
+  const platformAgent = process.env.npm_config_user_agent || "";
+  for (const platform of platforms) {
+    if (platformAgent.startsWith(platform)) return platform;
+  }
+  return false;
+};
+
+const platform = detectPlatform();
+
+export const install = () => {
+  switch (platform) {
+    case "npm":
+      execa("npm", ["install"]);
+    case "yarn/1":
+    case "yarn/2":
+      execa("yarn", ["install"]);
+    case "pnpm":
+      execa("pnpm", ["install"]);
+  }
+};

--- a/packages/create-obsidian-plugin/src/utils/platform.ts
+++ b/packages/create-obsidian-plugin/src/utils/platform.ts
@@ -1,25 +1,38 @@
+import os from "os";
 import execa from "execa";
 
-export type Platform = typeof platforms[number] | false;
+export type Platform = typeof platforms[number];
 const platforms = ["npm", "yarn/1", "yarn/2", "pnpm"] as const;
 export const detectPlatform = (): Platform => {
   const platformAgent = process.env.npm_config_user_agent || "";
   for (const platform of platforms) {
     if (platformAgent.startsWith(platform)) return platform;
   }
-  return false;
+  return "npm";
 };
 
 const platform = detectPlatform();
 
-export const install = () => {
+export const runCommandText = (cmd?: string) => {
   switch (platform) {
-    case "npm":
-      execa("npm", ["install"]);
     case "yarn/1":
     case "yarn/2":
-      execa("yarn", ["install"]);
-    case "pnpm":
-      execa("pnpm", ["install"]);
+      return `yarn ${cmd}`;
+    default:
+      return `${platform} run ${cmd}`;
   }
 };
+
+export const install = (cwd = process.cwd()) => {
+  switch (platform) {
+    case "npm":
+      return execa("npm", ["install"], { cwd });
+    case "yarn/1":
+    case "yarn/2":
+      return execa("yarn", ["install"], { cwd });
+    case "pnpm":
+      return execa("pnpm", ["install"], { cwd });
+  }
+};
+
+export const cmd = os.platform() === "darwin" ? "⌘" : "ctrl";

--- a/packages/create-obsidian-plugin/tsconfig.json
+++ b/packages/create-obsidian-plugin/tsconfig.json
@@ -1,0 +1,70 @@
+{
+  "compilerOptions": {
+    /* Visit https://aka.ms/tsconfig.json to read more about this file */
+
+    /* Basic Options */
+    // "incremental": true,                   /* Enable incremental compilation */
+    "target": "es5",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
+    "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */
+    // "lib": [],                             /* Specify library files to be included in the compilation. */
+    // "allowJs": true,                       /* Allow javascript files to be compiled. */
+    // "checkJs": true,                       /* Report errors in .js files. */
+    // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
+    // "declaration": true,                   /* Generates corresponding '.d.ts' file. */
+    // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
+    // "sourceMap": true,                     /* Generates corresponding '.map' file. */
+    // "outFile": "./",                       /* Concatenate and emit output to single file. */
+    "outDir": "./lib",                        /* Redirect output structure to the directory. */
+    // "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
+    // "composite": true,                     /* Enable project compilation */
+    // "tsBuildInfoFile": "./",               /* Specify file to store incremental compilation information */
+    // "removeComments": true,                /* Do not emit comments to output. */
+    // "noEmit": true,                        /* Do not emit outputs. */
+    // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
+    // "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
+    // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
+
+    /* Strict Type-Checking Options */
+    "strict": true,                           /* Enable all strict type-checking options. */
+    // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
+    // "strictNullChecks": true,              /* Enable strict null checks. */
+    // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
+    // "strictBindCallApply": true,           /* Enable strict 'bind', 'call', and 'apply' methods on functions. */
+    // "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */
+    // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
+    // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
+
+    /* Additional Checks */
+    // "noUnusedLocals": true,                /* Report errors on unused locals. */
+    // "noUnusedParameters": true,            /* Report errors on unused parameters. */
+    // "noImplicitReturns": true,             /* Report error when not all code paths in function return a value. */
+    // "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
+    // "noUncheckedIndexedAccess": true,      /* Include 'undefined' in index signature results */
+
+    /* Module Resolution Options */
+    "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+    // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
+    // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
+    // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
+    // "typeRoots": [],                       /* List of folders to include type definitions from. */
+    // "types": [],                           /* Type declaration files to be included in compilation. */
+    // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
+    "esModuleInterop": true,                  /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+    // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
+    // "allowUmdGlobalAccess": true,          /* Allow accessing UMD globals from modules. */
+
+    /* Source Map Options */
+    // "sourceRoot": "",                      /* Specify the location where debugger should locate TypeScript files instead of source locations. */
+    // "mapRoot": "",                         /* Specify the location where debugger should locate map files instead of generated locations. */
+    // "inlineSourceMap": true,               /* Emit a single file with source maps instead of having a separate file. */
+    // "inlineSources": true,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
+
+    /* Experimental Options */
+    // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
+    // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
+
+    /* Advanced Options */
+    "skipLibCheck": true,                     /* Skip type checking of declaration files. */
+    "forceConsistentCasingInFileNames": true  /* Disallow inconsistently-cased references to the same file. */
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1650,6 +1650,11 @@ assign-symbols@^1.0.0:
   resolved "https://registry.yarnpkg.com/assign-symbols/-/assign-symbols-1.0.0.tgz#59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367"
   integrity sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=
 
+async@0.9.x:
+  version "0.9.2"
+  resolved "https://registry.yarnpkg.com/async/-/async-0.9.2.tgz#aea74d5e61c1f899613bf64bda66d4c78f2fd17d"
+  integrity sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=
+
 async@^3.0.1:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/async/-/async-3.2.0.tgz#b3a2685c5ebb641d3de02d161002c60fc9f85720"
@@ -2464,7 +2469,7 @@ cross-spawn@^6.0.0, cross-spawn@^6.0.5:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
-cross-spawn@^7.0.0:
+cross-spawn@^7.0.0, cross-spawn@^7.0.3:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
   integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==
@@ -2732,6 +2737,13 @@ ecc-jsbn@~0.1.1:
     jsbn "~0.1.0"
     safer-buffer "^2.1.0"
 
+ejs@^3.1.6:
+  version "3.1.6"
+  resolved "https://registry.yarnpkg.com/ejs/-/ejs-3.1.6.tgz#5bfd0a0689743bb5268b3550cceeebbc1702822a"
+  integrity sha512-9lt9Zse4hPucPkoP7FHDF0LQAlGyF9JVpnClFLFH3aSSbxmyoqINRpp/9wePWJTUl4KOQwRL72Iw3InHPDkoGw==
+  dependencies:
+    jake "^10.6.1"
+
 "emoji-regex@>=6.0.0 <=6.1.1":
   version "6.1.1"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-6.1.1.tgz#c6cd0ec1b0642e2a3c67a1137efc5e796da4f88e"
@@ -2919,6 +2931,21 @@ execa@^4.0.0:
     signal-exit "^3.0.2"
     strip-final-newline "^2.0.0"
 
+execa@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-5.0.0.tgz#4029b0007998a841fbd1032e5f4de86a3c1e3376"
+  integrity sha512-ov6w/2LCiuyO4RLYGdpFGjkcs0wMTgGE8PrkTHikeUy5iJekXyPIKUjifk5CsE0pt7sMCrMZ3YNqoCj6idQOnQ==
+  dependencies:
+    cross-spawn "^7.0.3"
+    get-stream "^6.0.0"
+    human-signals "^2.1.0"
+    is-stream "^2.0.0"
+    merge-stream "^2.0.0"
+    npm-run-path "^4.0.1"
+    onetime "^5.1.2"
+    signal-exit "^3.0.3"
+    strip-final-newline "^2.0.0"
+
 expand-brackets@^2.1.4:
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/expand-brackets/-/expand-brackets-2.1.4.tgz#b77735e315ce30f6b6eff0f83b04151a22449622"
@@ -3064,6 +3091,13 @@ file-type@^16.0.0:
     strtok3 "^6.0.3"
     token-types "^2.0.0"
     typedarray-to-buffer "^3.1.5"
+
+filelist@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/filelist/-/filelist-1.0.2.tgz#80202f21462d4d1c2e214119b1807c1bc0380e5b"
+  integrity sha512-z7O0IS8Plc39rTCq6i6iHxk43duYOn8uFJiWSewIq0Bww1RNybVHSCjahmcC87ZqAm4OTvFzlzeGu3XAzG1ctQ==
+  dependencies:
+    minimatch "^3.0.4"
 
 fill-range@^4.0.0:
   version "4.0.0"
@@ -3332,6 +3366,11 @@ get-stream@^5.0.0, get-stream@^5.1.0:
   integrity sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==
   dependencies:
     pump "^3.0.0"
+
+get-stream@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-6.0.0.tgz#3e0012cb6827319da2706e601a1583e8629a6718"
+  integrity sha512-A1B3Bh1UmL0bidM/YX2NsCOTnGJePL9rO/M+Mw3m9f2gUpfokS0hi5Eah0WSUEWZdZhIZtMjkIYS7mDfOqNHbg==
 
 get-value@^2.0.3, get-value@^2.0.6:
   version "2.0.6"
@@ -3686,6 +3725,11 @@ human-signals@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-1.1.1.tgz#c5b1cd14f50aeae09ab6c59fe63ba3395fe4dfa3"
   integrity sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==
+
+human-signals@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-2.1.0.tgz#dc91fcba42e4d06e4abaed33b3e7a3c02f514ea0"
+  integrity sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==
 
 humanize-ms@^1.2.1:
   version "1.2.1"
@@ -4212,6 +4256,16 @@ isstream@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
   integrity sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=
+
+jake@^10.6.1:
+  version "10.8.2"
+  resolved "https://registry.yarnpkg.com/jake/-/jake-10.8.2.tgz#ebc9de8558160a66d82d0eadc6a2e58fbc500a7b"
+  integrity sha512-eLpKyrfG3mzvGE2Du8VoPbeSkRry093+tyNjdYaBbJS9v17knImYGNXQCUV0gLxQtF82m3E8iRb/wdSQZLoq7A==
+  dependencies:
+    async "0.9.x"
+    chalk "^2.4.2"
+    filelist "^1.0.1"
+    minimatch "^3.0.4"
 
 java-properties@^1.0.0:
   version "1.0.2"
@@ -5080,7 +5134,7 @@ npm-run-path@^2.0.0:
   dependencies:
     path-key "^2.0.0"
 
-npm-run-path@^4.0.0:
+npm-run-path@^4.0.0, npm-run-path@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-4.0.1.tgz#b7ecd1e5ed53da8e37a55e1c2269e0b97ed748ea"
   integrity sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==
@@ -5199,7 +5253,7 @@ onetime@^2.0.0:
   dependencies:
     mimic-fn "^1.0.0"
 
-onetime@^5.1.0:
+onetime@^5.1.0, onetime@^5.1.2:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/onetime/-/onetime-5.1.2.tgz#d0e96ebb56b07476df1dd9c4806e5237985ca45e"
   integrity sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==
@@ -6225,7 +6279,7 @@ shiki@^0.9.2:
     onigasm "^2.2.5"
     vscode-textmate "^5.2.0"
 
-signal-exit@^3.0.0, signal-exit@^3.0.2:
+signal-exit@^3.0.0, signal-exit@^3.0.2, signal-exit@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.3.tgz#a1410c2edd8f077b08b4e253c8eacfcaf057461c"
   integrity sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1283,6 +1283,11 @@
   resolved "https://registry.yarnpkg.com/@types/dedent/-/dedent-0.7.0.tgz#155f339ca404e6dd90b9ce46a3f78fd69ca9b050"
   integrity sha512-EGlKlgMhnLt/cM4DbUSafFdrkeJoC9Mvnj0PUCU7tFmTjMjNRT957kXCx0wYm3JuEq4o4ZsS5vG+NlkM2DMd2A==
 
+"@types/ejs@^3.0.6":
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/@types/ejs/-/ejs-3.0.6.tgz#aca442289df623bfa8e47c23961f0357847b83fe"
+  integrity sha512-fj1hi+ZSW0xPLrJJD+YNwIh9GZbyaIepG26E/gXvp8nCa2pYokxUYO1sK9qjGxp2g8ryZYuon7wmjpwE2cyASQ==
+
 "@types/estree@*":
   version "0.0.46"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.46.tgz#0fb6bfbbeabd7a30880504993369c4bf1deab1fe"
@@ -1333,6 +1338,11 @@
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"
   integrity sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==
+
+"@types/prettier@^2.2.2":
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.2.2.tgz#e2280c89ddcbeef340099d6968d8c86ba155fdf6"
+  integrity sha512-i99hy7Ki19EqVOl77WplDrvgNugHnsSjECVR/wUrzw2TJXz1zlUfT2ngGckR6xN7yFYaijsMAqPkOLx9HgUqHg==
 
 "@types/prompts@^2.0.9":
   version "2.0.9"
@@ -5636,6 +5646,11 @@ prepend-http@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-2.0.0.tgz#e92434bfa5ea8c19f41cdfd401d741a3c819d897"
   integrity sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=
+
+prettier@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.2.1.tgz#795a1a78dd52f073da0cd42b21f9c91381923ff5"
+  integrity sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==
 
 pretty-ms@^7.0.0:
   version "7.0.1"


### PR DESCRIPTION
There's not a _whole_ lot here yet, but there will at least be a mostly complete plugin environment for folks to dig into. 

Still missing:
- docs
- tests
- ci

It just uses the `main.ts` from the sample at the moment, but I think it'd be better to pair that down a bit an maybe provide some generation tools through the CLI for convenience sake. 

That'll all wait for later. 

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install create-obsidian-plugin@0.0.4-canary.38.6379857.0
  # or 
  yarn add create-obsidian-plugin@0.0.4-canary.38.6379857.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
