### PR TITLE
Add bin to create-obsidian-plugin

### DIFF
--- a/packages/create-obsidian-plugin/package.json
+++ b/packages/create-obsidian-plugin/package.json
@@ -8,6 +8,9 @@
     "plugin",
     "obsidian.md"
   ],
+  "bin": {
+    "create-obsidian-plugin": "./bin/run"
+  },
   "author": "Justin Bennett <zephraph@gmail.com>",
   "homepage": "https://github.com/zephraph/obsidian-tools#readme",
   "license": "MIT",


### PR DESCRIPTION
oops
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install create-obsidian-plugin@0.1.1-canary.39.ca0a1d2.0
  # or 
  yarn add create-obsidian-plugin@0.1.1-canary.39.ca0a1d2.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
