### PR TITLE
Add WSL support to obsidian-utils findVault

### DIFF
--- a/packages/obsidian-utils/package.json
+++ b/packages/obsidian-utils/package.json
@@ -41,6 +41,7 @@
     "@types/date-fns": "^2.6.0",
     "@types/node": "^14.14.28",
     "@types/node-fetch": "^2.5.8",
+    "@types/which": "^2.0.0",
     "esbuild": "^0.8.49",
     "obsidian": "obsidianmd/obsidian-api",
     "typedoc": "^0.20.28",
@@ -49,7 +50,9 @@
   },
   "dependencies": {
     "date-fns": "^2.17.0",
-    "node-fetch": "^2.6.1"
+    "execa": "^5.0.0",
+    "node-fetch": "^2.6.1",
+    "which": "^2.0.2"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1379,6 +1379,11 @@
     "@types/configstore" "*"
     boxen "^4.2.0"
 
+"@types/which@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@types/which/-/which-2.0.0.tgz#446d35586611dee657120de8e0457382a658fc25"
+  integrity sha512-JHTNOEpZnACQdsTojWggn+SQ8IucfqEhtz7g8Z0G67WdSj4x3F0X5I2c/CVcl8z/QukGrIHeQ/N49v1au74XFQ==
+
 "@zkochan/cmd-shim@^3.1.0":
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/@zkochan/cmd-shim/-/cmd-shim-3.1.0.tgz#2ab8ed81f5bb5452a85f25758eb9b8681982fd2e"
@@ -7309,7 +7314,7 @@ which@^1.2.9, which@^1.3.1:
   dependencies:
     isexe "^2.0.0"
 
-which@^2.0.1:
+which@^2.0.1, which@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/which/-/which-2.0.2.tgz#7c6a8dd0a636a0327e10b59c9286eee93f3f51b1"
   integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==


### PR DESCRIPTION
This PR adds support for finding vaults when running commands via WSL. It makes the assumption that the vault isn't located in the WSL instance, but rather on the host. 

It also makes the windows configuration search a bit safer by looking in `Local`, `Roaming`, and `LocalLow` inside of `AppData`.