### PR TITLE
Remove unused create-obsidian-plugin test

### DIFF
--- a/packages/create-obsidian-plugin/__tests__/create-obsidian-plugin.test.js
+++ b/packages/create-obsidian-plugin/__tests__/create-obsidian-plugin.test.js
@@ -1,7 +1,0 @@
-'use strict';
-
-const createObsidianPlugin = require('..');
-
-describe('create-obsidian-plugin', () => {
-    it('needs tests');
-});


### PR DESCRIPTION
Just some cleanup
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install create-obsidian-plugin@0.4.1-canary.49.8220854.0
  # or 
  yarn add create-obsidian-plugin@0.4.1-canary.49.8220854.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
