### PR TITLE
Bump esbuild version

### DIFF
--- a/packages/obsidian-plugin-cli/package.json
+++ b/packages/obsidian-plugin-cli/package.json
@@ -14,7 +14,7 @@
     "ansi-colors": "^4.1.1",
     "cosmiconfig": "^7.0.0",
     "dedent": "^0.7.0",
-    "esbuild": "^0.8.48",
+    "esbuild": "^0.12.6",
     "obsidian-utils": "^0.9.0",
     "prompts": "^2.4.0",
     "tslib": "^1",

--- a/packages/obsidian-plugin-cli/src/commands/build.ts
+++ b/packages/obsidian-plugin-cli/src/commands/build.ts
@@ -44,7 +44,7 @@ export default class Build extends Command {
     }
 
     if (stylesheet) {
-      esbuildConfig!.entryPoints!.push(stylesheet);
+      (esbuildConfig!.entryPoints as string[]).push(stylesheet);
       await build({
         outdir: outputDir,
         minify: true,

--- a/packages/obsidian-plugin-cli/src/commands/dev.ts
+++ b/packages/obsidian-plugin-cli/src/commands/dev.ts
@@ -207,7 +207,7 @@ export default class Dev extends Command {
     });
 
     if (stylesheet) {
-      esbuildConfig!.entryPoints!.push(stylesheet);
+      (esbuildConfig!.entryPoints as string[]).push(stylesheet);
       await build({
         outdir: pluginPath,
         watch: true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2875,10 +2875,15 @@ es6-promisify@^5.0.0:
   dependencies:
     es6-promise "^4.0.3"
 
-esbuild@^0.8.48, esbuild@^0.8.49:
-  version "0.8.49"
-  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.8.49.tgz#3d33f71b3966611f822cf4c838115f3fbd16def2"
-  integrity sha512-itiFVYv5UZz4NooO7/Y0bRGVDGz/M/cxKbl6zyNI5pnKaz1mZjvZXAFhhDVz6rGCmcdTKj5oag6rh8DaaSSmfQ==
+esbuild@^0.12.6:
+  version "0.12.6"
+  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.12.6.tgz#85bc755c7cf3005d4f34b4f10f98049ce0ee67ce"
+  integrity sha512-RDvVLvAjsq/kIZJoneMiUOH7EE7t2QaW7T3Q7EdQij14+bZbDq5sndb0tTanmHIFSqZVMBMMyqzVHkS3dJobeA==
+
+esbuild@^0.8.49:
+  version "0.8.57"
+  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.8.57.tgz#a42d02bc2b57c70bcd0ef897fe244766bb6dd926"
+  integrity sha512-j02SFrUwFTRUqiY0Kjplwjm1psuzO1d6AjaXKuOR9hrY0HuPsT6sV42B6myW34h1q4CRy+Y3g4RU/cGJeI/nNA==
 
 escape-goat@^2.0.0:
   version "2.1.1"


### PR DESCRIPTION
Bumps the version of esbuild as suggested by #50. I'll follow up on the incorrect filename for the css output. 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install create-obsidian-plugin@0.4.1-canary.51.3527c70.0
  npm install obsidian-plugin-cli@0.6.1-canary.51.3527c70.0
  # or 
  yarn add create-obsidian-plugin@0.4.1-canary.51.3527c70.0
  yarn add obsidian-plugin-cli@0.6.1-canary.51.3527c70.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
